### PR TITLE
Refactor logging configuration

### DIFF
--- a/lymph/cli/main.py
+++ b/lymph/cli/main.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import blessings
 
@@ -48,6 +49,11 @@ def setup_terminal(args, config):
     return blessings.Terminal(force_styling=force_color)
 
 
+def _excepthook(type, value, tb):
+    logger = logging.getLogger('lymph')
+    logger.log(logging.CRITICAL, 'Uncaught exception', exc_info=(type, value, tb))
+
+
 def main(argv=None):
     import lymph.monkey
     lymph.monkey.patch()
@@ -57,6 +63,8 @@ def main(argv=None):
     from lymph import __version__ as VERSION
     from lymph.cli.help import HELP
     from lymph.cli.base import get_command_class
+
+    sys.excepthook = _excepthook
 
     args = docopt.docopt(HELP, argv, version=VERSION, options_first=True)
     name = args.pop('<command>')

--- a/lymph/discovery/zookeeper.py
+++ b/lymph/discovery/zookeeper.py
@@ -10,6 +10,7 @@ from kazoo.exceptions import NoNodeError, ConnectionLoss
 
 from .base import BaseServiceRegistry
 from lymph.exceptions import LookupFailure, RegistrationFailure
+from lymph.utils.logging import setup_logger
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class ZookeeperServiceRegistry(BaseServiceRegistry):
         )
 
     def on_start(self, timeout=10):
+        setup_logger('kazoo')
         self.start_count += 1
         if self.start_count > 1:
             return

--- a/lymph/utils/logging.py
+++ b/lymph/utils/logging.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
-
 import logging
-import six
+from logging.config import dictConfig
 
+import six
 import zmq.green as zmq
 
 from lymph.utils.sockets import bind_zmq_socket
@@ -15,6 +15,16 @@ def get_loglevel(level_name):
     return getattr(logging, level)
 
 
+def setup_logger(name):
+    """Setup and return logger ``name`` with same settings as 'lymph' logger."""
+    lymph_logger = logging.getLogger('lymph')
+    logger = logging.getLogger(name)
+    for hdlr in lymph_logger.handlers:
+        logger.addHandler(hdlr)
+    logger.setLevel(lymph_logger.level)
+    return logger
+
+
 class PubLogHandler(logging.Handler):
     def __init__(self, endpoint):
         super(PubLogHandler, self).__init__()
@@ -25,12 +35,44 @@ class PubLogHandler(logging.Handler):
     def emit(self, record):
         topic = record.levelname
         self.socket.send_multipart([
-            _encode(topic),
-            _encode(self.endpoint),
-            _encode(self.format(record))])
+            self._encode(topic),
+            self._encode(self.endpoint),
+            self._encode(self.format(record))])
+
+    @staticmethod
+    def _encode(potentially_text, encoding='utf-8'):
+        if isinstance(potentially_text, six.text_type):
+            return potentially_text.encode(encoding)
+        return potentially_text
 
 
-def _encode(potentially_text, encoding='utf-8'):
-    if isinstance(potentially_text, six.text_type):
-        return potentially_text.encode(encoding)
-    return potentially_text
+def setup_logging(logconf, loglevel, logfile, log_endpoint):
+    logconf.setdefault('version', 1)
+    formatters = logconf.setdefault('formatters', {})
+    formatters.setdefault('_trace', {
+        '()': 'lymph.core.trace.TraceFormatter',
+        'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s - (trace-id:%(trace_id)s)',
+    })
+    handlers = logconf.setdefault('handlers', {})
+    handlers.setdefault('_zmqpub', {
+        'class': 'lymph.utils.logging.PubLogHandler',
+        'formatter': '_trace',
+        'endpoint': log_endpoint,
+    })
+    console_logconf = {
+        'class': 'logging.StreamHandler',
+        'formatter': '_trace',
+        'level': loglevel.upper(),
+    }
+    if logfile:
+        console_logconf.update({
+            'class': 'logging.FileHandler',
+            'filename': logfile
+        })
+    handlers.setdefault('_console', console_logconf)
+    loggers = logconf.setdefault('loggers', {})
+    loggers.setdefault('lymph', {
+        'handlers': ['_console', '_zmqpub'],
+        'level': 'DEBUG',
+    })
+    dictConfig(logconf)

--- a/lymph/utils/logging.py
+++ b/lymph/utils/logging.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import logging
 from logging.config import dictConfig
 

--- a/lymph/web/interfaces.py
+++ b/lymph/web/interfaces.py
@@ -1,5 +1,5 @@
-import sys
 import logging
+import sys
 
 from gevent.pywsgi import WSGIServer
 from werkzeug.wrappers import Request
@@ -7,6 +7,7 @@ from werkzeug.exceptions import HTTPException
 
 from lymph.core.interfaces import Interface
 from lymph.core import trace
+from lymph.utils.logging import setup_logger
 from lymph.exceptions import SocketNotCreated
 from lymph.utils.sockets import create_socket
 
@@ -31,6 +32,8 @@ class WebServiceInterface(Interface):
 
     def on_start(self):
         super(WebServiceInterface, self).on_start()
+        setup_logger('werkzeug')
+        setup_logger('gevent')
         try:
             socket_fd = self.container.get_shared_socket_fd(self.http_port)
         except SocketNotCreated:


### PR DESCRIPTION
Move logging configuration to lymph.utils.logging and add a new function
setup_logger that can be used by specific drivers and lymph extentions
to setup logging for specific logger instead of having hardcoded logger
configuration in lymph.