### PR TITLE
Fix message in LookupFailure

### DIFF
--- a/lymph/discovery/service.py
+++ b/lymph/discovery/service.py
@@ -42,7 +42,7 @@ class LymphCoordinatorServiceRegistry(BaseServiceRegistry):
         try:
             msg = channel.get()
         except Timeout:
-            raise LookupFailure(None, "couldn't reach the coordinator")
+            raise LookupFailure("couldn't reach the coordinator")
         return msg.body
 
     def lookup(self, service, timeout=1):
@@ -52,9 +52,9 @@ class LymphCoordinatorServiceRegistry(BaseServiceRegistry):
         try:
             msg = channel.get()
         except Timeout:
-            raise LookupFailure(None, "lookup of %s timed out" % service.service_name)
+            raise LookupFailure("lookup of %s timed out" % service.service_name)
         if not msg.body:
-            raise LookupFailure(None, "failed to resolve %s" % service.service_name)
+            raise LookupFailure("failed to resolve %s" % service.service_name)
         for info in msg.body:
             identity = info.pop('identity')
             service.update(identity, **info)

--- a/lymph/discovery/zookeeper.py
+++ b/lymph/discovery/zookeeper.py
@@ -101,7 +101,7 @@ class ZookeeperServiceRegistry(BaseServiceRegistry):
         try:
             names = result.get(timeout=timeout)
         except NoNodeError:
-            raise LookupFailure(None, "failed to resolve %s" % service.name)
+            raise LookupFailure("failed to resolve %s" % service.name)
         except ConnectionLoss:
             logger.warning("lost zookeeper connection")
             return service


### PR DESCRIPTION
This way the message will show up in the traceback instead of only the
class name.