### PR TITLE
make logging of trace-id Splunk-friendly

### DIFF
--- a/lymph/utils/logging.py
+++ b/lymph/utils/logging.py
@@ -73,7 +73,7 @@ def setup_logging(config, loglevel, logfile):
     formatters = logconf.setdefault('formatters', {})
     formatters.setdefault('_trace', {
         '()': 'lymph.core.trace.TraceFormatter',
-        'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s - (trace-id:%(trace_id)s)',
+        'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s - (trace-id=%(trace_id)s)',
     })
     handlers = logconf.setdefault('handlers', {})
     handlers.setdefault('_zmqpub', {


### PR DESCRIPTION
Splunk detects key-values pairs in the form of `key1=value1, key2=value2, key3=value3 . . .`

See http://dev.splunk.com/view/logging-best-practices/SP-CAAADP6