### PR TITLE
Fix reporting errors when handling events

### DIFF
--- a/lymph/events/base.py
+++ b/lymph/events/base.py
@@ -9,7 +9,7 @@ class BaseEventSystem(object):
         return cls(**kwargs)
 
     def install(self, container):
-        pass
+        self.container = container
 
     def on_start(self):
         pass


### PR DESCRIPTION
Change the event system to use container spawn and make sure that
any rejected message is reported to container error hook.