### PR TITLE
Always return a Service instance in lookup

### DIFF
--- a/lymph/core/container.py
+++ b/lymph/core/container.py
@@ -12,7 +12,7 @@ import six
 from lymph.exceptions import RegistrationFailure, SocketNotCreated
 from lymph.core.events import Event
 from lymph.core.monitoring import Monitor
-from lymph.core.services import ServiceInstance
+from lymph.core.services import ServiceInstance, Service
 from lymph.core.rpc import ZmqRPCServer
 from lymph.core.interfaces import DefaultInterface
 from lymph.core.plugins import Hook
@@ -210,7 +210,8 @@ class ServiceContainer(object):
     def lookup(self, address):
         if '://' not in address:
             return self.service_registry.get(address)
-        return ServiceInstance(self, address)
+        instance = ServiceInstance(self, address)
+        return Service(self, address, instances=[instance])
 
     def discover(self):
         return self.service_registry.discover()


### PR DESCRIPTION
Don't make the return type depend on argument it's a bad practice
that yield many problems.