### PR TITLE
Setting the reader to utf-8 for web handler; supporting py34

### DIFF
--- a/lymph/web/handlers.py
+++ b/lymph/web/handlers.py
@@ -1,3 +1,4 @@
+import codecs
 import json
 
 from werkzeug.exceptions import MethodNotAllowed
@@ -7,6 +8,9 @@ http_methods = ('get', 'post', 'head', 'options', 'put', 'delete')
 
 
 class RequestHandler(object):
+
+    stream_reader = codecs.getreader("utf-8")
+
     def __init__(self, interface, request):
         self.request = request
         self.interface = interface
@@ -19,7 +23,7 @@ class RequestHandler(object):
     def json(self):
         # FIXME: should we really keep a reference to the parsed body?
         if self._json is None:
-            self._json = json.load(self.request.stream)
+            self._json = json.load(self.stream_reader(self.request.stream))
         return self._json
 
     def dispatch(self, args):

--- a/lymph/web/handlers.py
+++ b/lymph/web/handlers.py
@@ -19,9 +19,10 @@ class RequestHandler(object):
         return [method.upper() for method in http_methods if callable(getattr(self, method))]
 
     def json(self):
-        # FIXME: should we really keep a reference to the parsed body?
-        request_is_json = "application/json" == self.request.mimetype
-        if request_is_json and self._json is None:
+        if not "application/json" == self.request.mimetype:
+            raise ValueError("The request Content-Type is not JSON")
+
+        if self._json is None:
             reader = codecs.getreader(self.request.charset)
             self._json = json.load(reader(self.request.stream))
         return self._json

--- a/lymph/web/handlers.py
+++ b/lymph/web/handlers.py
@@ -9,8 +9,6 @@ http_methods = ('get', 'post', 'head', 'options', 'put', 'delete')
 
 class RequestHandler(object):
 
-    stream_reader = codecs.getreader("utf-8")
-
     def __init__(self, interface, request):
         self.request = request
         self.interface = interface
@@ -22,8 +20,10 @@ class RequestHandler(object):
 
     def json(self):
         # FIXME: should we really keep a reference to the parsed body?
-        if self._json is None:
-            self._json = json.load(self.stream_reader(self.request.stream))
+        request_is_json = "application/json" == self.request.mimetype
+        if request_is_json and self._json is None:
+            reader = codecs.getreader(self.request.charset)
+            self._json = json.load(reader(self.request.stream))
         return self._json
 
     def dispatch(self, args):

--- a/lymph/web/interfaces.py
+++ b/lymph/web/interfaces.py
@@ -1,7 +1,8 @@
 import logging
 import sys
 
-from werkzeug.wrappers import Request, Response
+from werkzeug.contrib.wrappers import DynamicCharsetRequestMixin
+from werkzeug.wrappers import Request as BaseRequest, Response
 from werkzeug.exceptions import HTTPException
 
 from lymph.core.interfaces import Interface
@@ -13,6 +14,10 @@ from lymph.web.wsgi_server import LymphWSGIServer
 
 
 logger = logging.getLogger(__name__)
+
+
+class Request(DynamicCharsetRequestMixin, BaseRequest):
+    default_charset = 'utf-8'
 
 
 class WebServiceInterface(Interface):


### PR DESCRIPTION
When running a WebInterface on python3.4 a TypeError is raised when you try to access the `json` attribute of the interface.

```
TypeError: the JSON object must be str, not 'bytes'
```

We have to decode the stream to utf-8 to be able to support py34.