### PR TITLE
Fix discover method interface

### DIFF
--- a/lymph/discovery/base.py
+++ b/lymph/discovery/base.py
@@ -28,7 +28,7 @@ class BaseServiceRegistry(object):
         self.container = container
 
     @abstractmethod
-    def discover(self, container):
+    def discover(self):
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
The discover method is not supposed to take an argument as it is also
specified in this interface implementation.