### PR TITLE
Add the container service name to the process name

### DIFF
--- a/lymph/cli/service.py
+++ b/lymph/cli/service.py
@@ -74,8 +74,9 @@ class InstanceCommand(Command):
         gevent.signal(signal.SIGINT, handle_signal)
         gevent.signal(signal.SIGTERM, handle_signal)
 
-        setproctitle('lymph-instance (identity: %s, endpoint: %s, config: %s)' % (
+        setproctitle('lymph-instance (identity: %s, service_name: %s, endpoint: %s, config: %s)' % (
             container.identity,
+            container.service_name,
             container.endpoint,
             self.config.source,
         ))


### PR DESCRIPTION
A service should export his service_name to be more easily traced via `ps`