### PR TITLE
Add a better way to guess external ip

### DIFF
--- a/lymph/cli/main.py
+++ b/lymph/cli/main.py
@@ -27,9 +27,10 @@ def setup_config(args):
     ip = args.get('--ip')
     if args.get('--guess-external-ip'):
         if ip:
-            print('cannot combine --ip and --guess-external-ip')
-            return 1
+            sys.exit('Cannot combine --ip and --guess-external-ip')
         ip = guess_external_ip()
+        if ip is None:
+            sys.exit('Cannot guess external ip, aborting ...')
     if ip:
         config.set('container.ip', ip)
 

--- a/lymph/utils/sockets.py
+++ b/lymph/utils/sockets.py
@@ -1,14 +1,17 @@
-
-
 import socket
 import os
+
 from six.moves import urllib
+import netifaces
 
 
 def guess_external_ip():
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(('google.com', 65056))
-    return s.getsockname()[0]
+    gateways = netifaces.gateways()
+    try:
+         ifnet = gateways['default'][netifaces.AF_INET][1]
+         return netifaces.ifaddresses(ifnet)[netifaces.AF_INET][0]['addr']
+    except (KeyError, IndexError):
+        return
 
 
 def bind_zmq_socket(sock, address, port=None):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,3 +12,4 @@ redis==2.9.1
 setproctitle==1.1.8
 six==1.6.1
 blessings==1.5.1
+netifaces==0.10.4


### PR DESCRIPTION
This doesn't need a DNS resolver to be set up or an external
request to be made which fix the problem in case a node is
not connected to internet.