### PR TITLE
Dump threads stack when SIGQUIT is send to process

### DIFF
--- a/lymph/core/container.py
+++ b/lymph/core/container.py
@@ -183,13 +183,13 @@ class ServiceContainer(object):
                     logger.error("registration failed %s, %s", interface_name, service)
                     self.stop()
 
-    def stop(self):
+    def stop(self, **kwargs):
         for service in six.itervalues(self.installed_interfaces):
-            service.on_stop()
-        self.event_system.on_stop()
-        self.service_registry.on_stop()
-        self.monitor.stop()
-        self.server.stop()
+            service.on_stop(**kwargs)
+        self.event_system.on_stop(**kwargs)
+        self.service_registry.on_stop(**kwargs)
+        self.monitor.stop(**kwargs)
+        self.server.stop(**kwargs)
         self.pool.kill()
 
     def join(self):

--- a/lymph/core/interfaces.py
+++ b/lymph/core/interfaces.py
@@ -14,7 +14,7 @@ class Component(object):
     def on_start(self):
         pass
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         pass
 
 
@@ -128,9 +128,9 @@ class Interface(object):
         for component in self.components.values():
             component.on_start()
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         for component in self.components.values():
-            component.on_stop()
+            component.on_stop(**kwargs)
 
     def on_connect(self, endpoint):
         pass

--- a/lymph/core/monitoring.py
+++ b/lymph/core/monitoring.py
@@ -37,7 +37,7 @@ class Monitor(object):
     def start(self):
         self.loop_greenlet = self.container.spawn(self.loop)
 
-    def stop(self):
+    def stop(self, **kwargs):
         self.loop_greenlet.kill()
 
     def get_rusage_stats(self, ru, previous):

--- a/lymph/core/rpc.py
+++ b/lymph/core/rpc.py
@@ -95,7 +95,7 @@ class ZmqRPCServer(object):
         self.running = True
         self.recv_loop_greenlet = self.container.spawn(self._recv_loop)
 
-    def stop(self):
+    def stop(self, **kwargs):
         self.running = False
         for connection in list(self.connections.values()):
             connection.close()

--- a/lymph/discovery/base.py
+++ b/lymph/discovery/base.py
@@ -12,7 +12,7 @@ class BaseServiceRegistry(object):
     def on_start(self):
         pass
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         pass
 
     def get(self, service_name, **kwargs):

--- a/lymph/discovery/zookeeper.py
+++ b/lymph/discovery/zookeeper.py
@@ -49,7 +49,7 @@ class ZookeeperServiceRegistry(BaseServiceRegistry):
             raise RuntimeError('could not connect to zookeeper')
         logger.debug('connected to zookeeper (version=%s)', '.'.join(map(str, self.client.server_version())))
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         self.start_count -= 1
         if self.start_count != 0:
             return

--- a/lymph/events/base.py
+++ b/lymph/events/base.py
@@ -14,7 +14,7 @@ class BaseEventSystem(object):
     def on_start(self):
         pass
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         pass
 
     def subscribe(self, container, handler):

--- a/lymph/events/kombu.py
+++ b/lymph/events/kombu.py
@@ -60,7 +60,7 @@ class EventConsumer(kombu.mixins.ConsumerMixin):
         self.should_stop = False
         self.greenlet = self.event_system.container.spawn(self.run)
 
-    def stop(self):
+    def stop(self, **kwargs):
         if not self.greenlet:
             return
         self.should_stop = True
@@ -75,9 +75,9 @@ class KombuEventSystem(BaseEventSystem):
         self.serializer = serializer
         self.consumers_by_queue = {}
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         for consumer in self.consumers_by_queue.values():
-            consumer.stop()
+            consumer.stop(**kwargs)
         self.consumers_by_queue.clear()
 
     @classmethod

--- a/lymph/services/node.py
+++ b/lymph/services/node.py
@@ -29,9 +29,13 @@ class Process(object):
             self.cmd, env=self.env, close_fds=False)
         self._process = psutil.Process(self._popen.pid)
 
-    def stop(self):
+    def stop(self, **kwargs):
+        signalnum = kwargs.get('signalnum')
         try:
-            self._process.terminate()
+            if signalnum:
+                self._process.send_signal(signalnum)
+            else:
+                self._process.terminate()
             self._process.wait()
         except psutil.NoSuchProcess:
             pass
@@ -100,12 +104,12 @@ class Node(Interface):
                 p.start()
         self.container.spawn(self.watch_processes)
 
-    def on_stop(self):
+    def on_stop(self, **kwargs):
         logger.info("waiting for all service processes to die ...")
         self.running = False
         for p in self.processes:
-            p.stop()
-        super(Node, self).on_stop()
+            p.stop(**kwargs)
+        super(Node, self).on_stop(**kwargs)
 
     def create_shared_sockets(self):
         for name, host, port in self._sockets:

--- a/lymph/testing/__init__.py
+++ b/lymph/testing/__init__.py
@@ -81,7 +81,7 @@ class MockServiceNetwork(object):
         for container in six.itervalues(self.service_containers):
             container.start()
 
-    def stop(self):
+    def stop(self, **kwargs):
         for container in six.itervalues(self.service_containers):
             container.stop()
 


### PR DESCRIPTION
SIGQUIT signal is meant to be used to produce a core dump when it terminates
the process, JAVA virtual machines already support this behaviour, this change
add it to lymph. This is very usefull feature when it come to test why a process
hang, and specially in a production environment, where when this happen ops can
just kill it using ``kill -3 <pid>`` which will produce a snapshot of all
greenlets and os-threads stack printed stderr.