### PR TITLE
Add ``--remote`` option to ``lymph shell``

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -93,10 +93,31 @@ This command takes the same commandline options as ``lymph instance``.
 ``lymph shell``
 ~~~~~~~~~~~~~~~
 
-Starts an interactive Python shell. The following objects will be available in the global namespace:
+Starts an interactive Python shell, locally or remotely.
+
+Locally:
+--------
+
+In case shell was open locally the following objects will be available in the
+global namespace:
 
 ``client``
     a configured :class:`lymph.client.Client` instance
 
 ``config``
     a loaded :class:`lymph.config.Configuration` instance
+
+Remotely:
+---------
+
+``lymph shell --remote=<name>`` can open a remote shell in a running services, but only
+if this service was run in ``--debug`` mode.
+
+In this shell you can have access to the current container instance as to some helper
+functions for debugging purposes:
+
+``container``
+    the :class:`lymph.core.container.Container`` instance
+
+``dump_stacks()``
+    helper function to dump stack of all running greenlets and os threads.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -143,3 +143,11 @@ The ``_console`` handler writes messages to either stdout or the file given by
 
 
 .. _dictConfig: https://docs.python.org/2/library/logging.config.html#configuration-dictionary-schema
+
+
+Debugging Configuration
+-----------------------
+
+.. describe:: debug:backdoor_ip
+
+Specify which ip address the backdoor terminal should listen too.

--- a/lymph/cli/main.py
+++ b/lymph/cli/main.py
@@ -79,7 +79,7 @@ def main(argv=None):
     config = setup_config(args) if command_cls.needs_config else None
 
     if config:
-        loglevel = args.get('--loglevel')
+        loglevel = args.get('--loglevel', 'ERROR')
         logfile = args.get('--logfile')
 
         lymph_logging.setup_logging(config, loglevel, logfile)

--- a/lymph/core/container.py
+++ b/lymph/core/container.py
@@ -43,6 +43,7 @@ class ServiceContainer(object):
         self.server = self.server_cls(self, ip, port)
         self.node_endpoint = node_endpoint
         self.log_endpoint = log_endpoint
+        self.backdoor_endpoint = None
         self.service_name = service_name
         self.fqdn = socket.getfqdn()
 
@@ -160,6 +161,7 @@ class ServiceContainer(object):
             'endpoint': self.endpoint,
             'identity': self.identity,
             'log_endpoint': self.log_endpoint,
+            'backdoor_endpoint': self.backdoor_endpoint,
             'fqdn': self.fqdn,
         }
 

--- a/lymph/core/services.py
+++ b/lymph/core/services.py
@@ -23,11 +23,9 @@ class ServiceInstance(object):
         self.update(endpoint, **info)
         self.connection = None
 
-    def update(self, endpoint, log_endpoint=None, name=None, fqdn=None):
+    def update(self, endpoint, **info):
         self.endpoint = endpoint
-        self.log_endpoint = log_endpoint
-        self.name = name
-        self.fqdn = fqdn
+        self.__dict__.update(info)
 
     def connect(self):
         self.connection = self.container.connect(self.endpoint)
@@ -55,6 +53,11 @@ class Service(observables.Observable):
 
     def __len__(self):
         return len(self.instances)
+
+    def get_instance(self, identity_prefix):
+        for instance in six.itervalues(self.instances):
+            if instance.identity.startswith(identity_prefix):
+                return instance
 
     def identities(self):
         return list(self.instances.keys())

--- a/lymph/tests/integration/test_cli.py
+++ b/lymph/tests/integration/test_cli.py
@@ -57,7 +57,7 @@ class ListCommandTests(CliTestMixin, unittest.TestCase):
             subscribe         Prints events to stdout.
             instance          Run a single service instance (one process).
             node              Run a node service that manages a group of processes on the same machine.
-            shell             Open an interactive Python shell.
+            shell             Open an interactive Python shell locally or remotely.
         """, config=False)
 
 

--- a/lymph/utils/sockets.py
+++ b/lymph/utils/sockets.py
@@ -74,3 +74,13 @@ def create_socket(host, family=socket.AF_INET, type=socket.SOCK_STREAM,
         os.set_inheritable(sock.fileno(), True)
 
     return sock
+
+
+def get_unused_port(host="127.0.0.1", family=socket.AF_INET, socktype=socket.SOCK_STREAM):
+    tempsock = socket.socket(family, socktype)
+    tempsock.bind((host, 0))
+    port = tempsock.getsockname()[1]
+    tempsock.close()
+    del tempsock
+    return port
+


### PR DESCRIPTION
1. Fix the backdoor terminal setup by removing the hardcoded port so
that we can have more than one service (and it instances) running
with a backdoor terminal, and make the backdoor listen ip configurable.

2. Make backdoor terminal endpoint discoverable by saving it to
zookeeper.

3. Add ``lymph terminal`` that open a telnet connection to remote
backdoor terminal of a give service.