### PR TITLE
Add support for one-time events

### DIFF
--- a/lymph/core/container.py
+++ b/lymph/core/container.py
@@ -154,7 +154,7 @@ class ServiceContainer(object):
         return self.event_system.subscribe(handler, **kwargs)
 
     def unsubscribe(self, handler):
-        self.event_system.unsubscribe(self, handler)
+        self.event_system.unsubscribe(handler)
 
     def get_instance_description(self, service_type=None):
         return {

--- a/lymph/core/events.py
+++ b/lymph/core/events.py
@@ -1,5 +1,6 @@
 import re
 import logging
+from uuid import uuid4
 
 from lymph.core.interfaces import Component
 from lymph.core import trace
@@ -42,17 +43,22 @@ class Event(object):
 
 
 class EventHandler(Component):
-    def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True):
+    def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True, once=False):
         self.func = func
         self.event_types = event_types
         self.sequential = sequential
         self.active = active
         self.interface = interface
+        self.once = once
+        self.unique_key = str(uuid4()) if once else None
         self._queue_name = queue_name or func.__name__
 
     @property
     def queue_name(self):
-        return '%s-%s' % (self.interface.name, self._queue_name)
+        if self.unique_key:
+            return '%s-%s-%s' % (self.interface.name, self._queue_name, self.unique_key)
+        else:
+            return '%s-%s' % (self.interface.name, self._queue_name)
 
     @queue_name.setter
     def queue_name(self, value):

--- a/lymph/exceptions.py
+++ b/lymph/exceptions.py
@@ -29,6 +29,10 @@ class RegistrationFailure(Exception):
     pass
 
 
+class EventHandlerTimeout(Exception):
+    pass
+
+
 class _RemoteException(type):
 
     # Hold dynamically generated exception classes.


### PR DESCRIPTION
Sample of usage:

```python
class ConsumerService(lymph.Interface):
    @lymph.rpc()
    def consume(self, **kwargs):
        ident = str(uuid4())
        async_result = self.get_next_event('onetime_event.%s' % ident)

        # Doing something that cause event
        self.proxy('producer').produce(ident=ident)

        result = async_result.get()  # Wait until event will be processed

        return {
            'source_id': ident,
            'target_id': result['target_id'],
            'generated_id': result['generated_id']
        }


class ProducerService(lymph.Interface):
    @lymph.rpc()
    def produce(self, ident, **kwargs):
        self.emit('onetime_event.%s' % ident, {
            'target_id': ident,
            'generated_id': str(uuid4())
        })
```