### PR TITLE
compute elapsed time in seconds for RPC call

### DIFF
--- a/lymph/core/rpc.py
+++ b/lymph/core/rpc.py
@@ -180,8 +180,8 @@ class ZmqRPCServer(object):
             except:
                 logger.exception('failed to send automatic NACK')
         finally:
-            elapsed = (time.time() - start) * (10 ** 3)
-            logger.log(loglevel, 'subject=%s duration=%.3f (seconds)', msg.subject, elapsed)
+            elapsed = time.time() - start
+            logger.log(loglevel, 'subject=%s duration=%f (seconds)', msg.subject, elapsed)
 
     def _get_loglevel(self, msg):
         return logging.DEBUG if msg.subject == 'lymph.ping' else logging.INFO

--- a/lymph/web/wsgi_server.py
+++ b/lymph/web/wsgi_server.py
@@ -14,8 +14,7 @@ class LymphWSGIHandler(WSGIHandler):
         # lymph logger format.
         length = self.response_length or '-'
         if self.time_finish:
-            duration= (self.time_finish - self.time_start) * (10 ** 3)
-            delta = '%.3f' % duration
+            delta = '%f' % (self.time_finish - self.time_start)
         else:
             delta = '-'
         client_address = self.client_address[0] if isinstance(self.client_address, tuple) else self.client_address


### PR DESCRIPTION
 * `time.time()` is returning seconds already (https://docs.python.org/2/library/time.html#time.time)