### PR TITLE
allow to guess external ip for shell command

### DIFF
--- a/lymph/cli/shell.py
+++ b/lymph/cli/shell.py
@@ -16,12 +16,14 @@ class ShellCommand(Command):
 
     Options:
       --remote=<name:identity-prefix>     Service instance name and identity.
+      --guess-external-ip, -g             Guess the public facing IP of this machine and
+                                          use it instead of the provided address.
 
     {COMMON_OPTIONS}
 
     Example:
 
-        $ lymph shell --remote=echo:38428b071a6
+        $ lymph shell --remote=echo:38428b071a6 --guess-external-ip
 
     """
 


### PR DESCRIPTION
Allow RPC to remote service from shell.

``` shell
$ lymph shell --guess-external-ip
...
In [1]: client.proxy('echo').upper(text='abc')
Out[1]: 'ABC'
```
(assuming that `echo` runs remotely)

As for why, check here:
 * https://github.com/deliveryhero/lymph/blob/master/lymph/cli/main.py#L28
 * https://github.com/deliveryhero/lymph/blob/master/lymph/cli/main.py#L68