### PR TITLE
Add enability to bound greenlets pool from configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,6 +71,9 @@ Container Configuration
 
     the ZeroMQ endpoint that monitoring data should be sent to.
 
+.. describe:: container:pool_size:
+
+    Size of the pool of Greenlets, default is unlimited.
 
 .. _interface-config:
 

--- a/lymph/contrib/gpool.py
+++ b/lymph/contrib/gpool.py
@@ -1,0 +1,38 @@
+from gevent.pool import Pool
+
+from lymph.exceptions import ResourceExhausted
+
+
+class RejectExcecutionError(ResourceExhausted):
+    pass
+
+
+class NonBlockingPool(Pool):
+    """A gevent pool that when exhausted will wait for a given timeout
+    for resources to be freed before rejecting the job by raising
+    exc:``RejectedExcecutionError``.
+
+    When the ``timeout`` is not given or set to None the pool will reject
+    immediately without waiting when pool size reach max size.
+
+    In case ``size`` is None this will create an unbound pool, this was
+    added for backward compatibility with old lymph behaviour so use it
+    at your own risk.
+
+    """
+
+    def __init__(self, timeout=None, **kwargs):
+        super(NonBlockingPool, self).__init__(**kwargs)
+        self._timeout = timeout
+
+    def add(self, greenlet):
+        acquired = self._semaphore.acquire(blocking=False, timeout=self._timeout)
+        # XXX(Mouad): Checking directly for False because DummySemaphore always
+        # return None https://github.com/gevent/gevent/pull/544.
+        if acquired is False:
+            raise RejectExcecutionError('No more resource available to run %r' % greenlet)
+        try:
+            super(NonBlockingPool, self).add(greenlet)
+        except:
+            self._semaphore.release()
+            raise

--- a/lymph/core/container.py
+++ b/lymph/core/container.py
@@ -39,7 +39,7 @@ class ServiceContainer(object):
 
     server_cls = ZmqRPCServer
 
-    def __init__(self, ip='127.0.0.1', port=None, registry=None, logger=None, events=None, node_endpoint=None, log_endpoint=None, service_name=None, debug=False, monitor_endpoint=None):
+    def __init__(self, ip='127.0.0.1', port=None, registry=None, logger=None, events=None, node_endpoint=None, log_endpoint=None, service_name=None, debug=False, monitor_endpoint=None, pool_size=None):
         self.server = self.server_cls(self, ip, port)
         self.node_endpoint = node_endpoint
         self.log_endpoint = log_endpoint
@@ -51,7 +51,7 @@ class ServiceContainer(object):
         self.event_system = events
 
         self.error_hook = Hook()
-        self.pool = trace.Group()
+        self.pool = trace.Group(size=pool_size)
 
         self.installed_interfaces = {}
         self.installed_plugins = []

--- a/lymph/exceptions.py
+++ b/lymph/exceptions.py
@@ -62,3 +62,7 @@ class SocketNotCreated(Exception):
 
 class NotConnected(Exception):
     pass
+
+
+class ResourceExhausted(Exception):
+    pass


### PR DESCRIPTION
Add a NonBlockingPool that in contrast of gevent.pool.Pool it's non blocking and
as soon as pool limit are reached it will reject work instead of blocking, which
can be very dangerous when you can block for ever and with it block calling greeenlet
in other services ... .

When Pool reject jobs it raise a ``ResourceExhausted`` subclass, the idea is to expose
this exception and then add a back pressure support with bulkhead pattern into client
for more resilience.

The NonBlockingPool is also used in gevent WSGI server to bound resources.