### PR TITLE
Make RpcMock test case a standalone class

### DIFF
--- a/lymph/testing/__init__.py
+++ b/lymph/testing/__init__.py
@@ -174,7 +174,7 @@ class ClientInterface(Interface):
     service_type = 'client'
 
 
-class LymphServiceTestCase(RpcMockTestCase):
+class LymphServiceTestCase(unittest.TestCase):
     client_class = ClientInterface
     client_name = 'client'
     client_config = {}
@@ -209,7 +209,7 @@ class LymphServiceTestCase(RpcMockTestCase):
         self.network.join()
 
 
-class APITestCase(RpcMockTestCase):
+class APITestCase(unittest.TestCase):
 
     interface_name = None
 


### PR DESCRIPTION
This will make having rpc calls mocked optional for developers to
either include in there test cases or no.