### PR TITLE
Guide the newbee user to the included help

### DIFF
--- a/lymph/cli/help.py
+++ b/lymph/cli/help.py
@@ -1,9 +1,14 @@
 from lymph.cli.base import Command, get_command_classes, get_command_class, format_docstring
 
 
-HELP = 'Usage: lymph [options] <command> [<args>...]'
+HEADER = 'Usage: lymph [options] <command> [<args>...]'
 
-TEMPLATE = HELP + """
+HELP = HEADER + """
+  lymph help             display help overview
+  lymph help <command>   display command documentation
+"""
+
+TEMPLATE = HEADER + """
 
 {COMMON_OPTIONS}
 
@@ -64,7 +69,8 @@ class HelpCommand(Command):
             cmds = []
             for name, cls in classes.items():
                 cmds.append(_format_help(name, cls.short_description))
-            self._description = format_docstring(TEMPLATE % '\n'.join(cmds))
+            self._description = (format_docstring(TEMPLATE % '\n'.join(cmds)) +
+                "\n\nlymph help <command>     to display command specific help")
         return self._description
 
     def run(self):

--- a/lymph/cli/main.py
+++ b/lymph/cli/main.py
@@ -71,7 +71,7 @@ def main(argv=None):
     try:
         command_cls = get_command_class(name)
     except KeyError:
-        print("'%s' is not a valid lymph command. See 'lymph list' or 'lymph --help'." % name)
+        print("'%s' is not a valid lymph command. See 'lymph list' or 'lymph help'." % name)
         return 1
     command_args = docopt.docopt(command_cls.get_help(), [name] + argv)
     args.update(command_args)


### PR DESCRIPTION
Before this, a plain `lymph` would just show

    Usage: lymph [options] <command> [<args>...]

which leaves no clue about how to use `lymph help`