### PR TITLE
Add a way to poll metrics from an interface

### DIFF
--- a/lymph/core/interfaces.py
+++ b/lymph/core/interfaces.py
@@ -161,3 +161,7 @@ class DefaultInterface(Interface):
         return {
             'methods': methods,
         }
+
+    @rpc()
+    def get_metrics(self):
+        return list(self.container.metrics)

--- a/lymph/tests/integration/test_zookeeper_discovery.py
+++ b/lymph/tests/integration/test_zookeeper_discovery.py
@@ -52,6 +52,10 @@ class ZookeeperIntegrationTest(LymphIntegrationTestCase):
             'identity': self.upper_container.identity,
         })
 
+    def test_get_metrics(self):
+        reply = self.lymph_client.request('upper', 'lymph.get_metrics', {})
+        self.assertIsInstance(reply.body, list)
+
     def test_connection_loss(self):
         service = self.lymph_client.container.lookup('upper')
         self.assertEqual(

--- a/lymph/tests/test_mockcontainer.py
+++ b/lymph/tests/test_mockcontainer.py
@@ -109,5 +109,6 @@ class BasicMockTest(unittest.TestCase):
         methods = proxy.inspect()['methods']
         self.assertEqual(set(m['name'] for m in methods), set([
             'upper.fail', 'upper.upper', 'upper.auto_nack', 'upper.just_ack',
-            'lymph.status', 'lymph.inspect', 'lymph.ping', 'upper.indirect_upper'
+            'lymph.status', 'lymph.inspect', 'lymph.ping', 'upper.indirect_upper',
+            'lymph.get_metrics',
         ]))


### PR DESCRIPTION
Since all metrics are send to one 0mq subscriber endpoint it's harder
to get metrics from a given interface, by using get_metrics() RPC function
users can have a quick look on a given interface metrics.

This just a first step, since get_metrics() call will return results from
different instances each time it's called in case we are running different
service instance, so for now this should only be used for debugging purposes.