### PR TITLE
Refactor metrics and add new out of the box metrics classes

### DIFF
--- a/docs/api/components_api.rst
+++ b/docs/api/components_api.rst
@@ -4,26 +4,27 @@
 Components API
 ==============
 
-Components are objects that depend on a running service container. They are 
-embedded in :class:`Componentized` objects. 
-Since Componentized objects themselves are components, they form a tree of 
-:class:`Component` instances with the container as the root.
+Components are objects that depend on a running service container. They are
+embedded in :class:`Componentized` objects.
+Since Componentized objects themselves are components, they form a tree of
+:class:`Component` instances with the container as the root. An example
+of a Component is :class:`lymph.core.interfaces.Interface`.
 
 
 .. class:: Component
 
-    .. attribute:: metrics
-    
-        A :class:`Metrics` instance that will be included in the monitoring data
-        of the conatainer.
-
     .. method:: on_start()
-    
+
         Called when the container is started.
 
     .. method:: on_stop()
-    
+
         Called when the container is stopped.
+
+    .. method:: _get_metrics()
+
+        Is being called to get metrics. Returns an iterable or yields
+        values of type :class:`lymph.core.monitoring.metrics.RawMetric`.
 
 
 .. class:: Componentized()
@@ -31,19 +32,15 @@ Since Componentized objects themselves are components, they form a tree of
     A collection of components; itself a component.
 
     .. method:: add_component(component)
-    
+
         :param component: :class:`Component`
-    
+
         Adds `component`.
-    
-    .. attribute:: metrics
-    
-        A :class:`Metrics` instance that aggregates the metrics from all added components.
-    
+
     .. method:: on_start()
-    
+
         Calls `on_start()` on all added components.
-    
+
     .. method:: on_stop()
 
         Calls `on_stop()` on all added components.

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,10 +6,11 @@ Contents:
 
 .. toctree::
     :maxdepth: 2
-   
+
     service_api
     core_api
     config_api
     web_api
     patterns_api
     components_api
+    metrics_api

--- a/docs/api/metrics_api.rst
+++ b/docs/api/metrics_api.rst
@@ -1,0 +1,37 @@
+.. currentmodule:: lymph.core.monitoring.metrics
+
+
+Metrics API
+===========
+
+
+.. class:: RawMetric(name, value, tags=None)
+
+   Raw metric that represent an arbitrary value a.k.a Gauge Metric.
+
+   .. method:: __iter__()
+
+      Yield metric values as a tuple in the form `(name, value, tags)`.
+
+
+.. class:: Counter(name, tags=None)
+
+    A counter is a cumulative metric that represents a single numerical
+    value that only ever goes up. A counter is typically used to count
+    requests served, tasks completed, errors occurred, etc.
+
+    .. method:: __iadd__(new_value=1)
+
+      Increment counter value.
+
+
+.. class:: TaggedCounter(name, tags=None)
+
+    A tagged counter is a container metric that represents multiple
+    counters per tags. A tagged counter is typically used to track a group
+    of counters as one e.g. request served per function name, errors ocurred
+    per exception name, etc.
+
+    .. method:: incr(_value=1, **tags)
+
+      Increment given counter ``type`` by ``new_value``.

--- a/lymph/core/components.py
+++ b/lymph/core/components.py
@@ -1,17 +1,16 @@
 import six
 
-from lymph.core.monitoring.metrics import Metrics
-
 
 class Component(object):
-    def __init__(self):
-        self.metrics = Metrics()
 
     def on_start(self):
         pass
 
     def on_stop(self, **kwargs):
         pass
+
+    def _get_metrics(self):
+        return []
 
 
 class Declaration(object):
@@ -57,7 +56,6 @@ class Componentized(Component):
 
     def add_component(self, component):
         self.__all_components.append(component)
-        self.metrics.add(component.metrics)
 
     def install(self, factory, **kwargs):
         if factory in self._declared_components:
@@ -77,3 +75,10 @@ class Componentized(Component):
     def on_stop(self, **kwargs):
         for component in reversed(self.__all_components):
             component.on_stop(**kwargs)
+
+    def _get_metrics(self):
+        for metric in super(Componentized, self)._get_metrics():
+            yield metric
+        for component in self.__all_components:
+            for metric in component._get_metrics():
+                yield metric

--- a/lymph/core/monitoring/aggregator.py
+++ b/lymph/core/monitoring/aggregator.py
@@ -1,0 +1,22 @@
+from lymph.core.monitoring.global_metrics import RUsageMetrics, GeventMetrics, GarbageCollectionMetrics
+
+
+class Aggregator(object):
+
+    def __init__(self, *getters, **tags):
+        self._metrics_getters = [
+            RUsageMetrics(),
+            GarbageCollectionMetrics(),
+            GeventMetrics(),
+        ] + list(getters)
+        self._tags = tags
+
+    def add_tags(self, **tags):
+        self._tags.update(tags)
+
+    def get_metrics(self):
+        for getter in self._metrics_getters:
+            for metrics in getter():
+                for name, value, tags in metrics:
+                    tags.update(self._tags)
+                    yield name, value, tags

--- a/lymph/core/monitoring/global_metrics.py
+++ b/lymph/core/monitoring/global_metrics.py
@@ -3,6 +3,8 @@ import gc
 import resource
 import gevent
 
+from . import metrics
+
 
 RUSAGE_ATTRS = (
     'utime', 'stime',
@@ -26,7 +28,7 @@ class RUsageMetrics(GlobalMetrics):
     def __iter__(self):
         ru = resource.getrusage(resource.RUSAGE_SELF)
         for ru_attr, series_name in self.attr_map:
-            yield series_name, getattr(ru, ru_attr), {}
+            yield metrics.RawMetric(series_name, getattr(ru, ru_attr))
 
 
 class GarbageCollectionMetrics(GlobalMetrics):
@@ -34,9 +36,9 @@ class GarbageCollectionMetrics(GlobalMetrics):
         self.name = name
 
     def __iter__(self):
-        yield '{}.garbage'.format(self.name), len(gc.garbage), {}
+        yield metrics.RawMetric('{}.garbage'.format(self.name), len(gc.garbage))
         for i, count in enumerate(gc.get_count()):
-            yield '{}.count{}'.format(self.name, i), count, {}
+            yield metrics.RawMetric('{}.count{}'.format(self.name, i), count)
 
 
 class GeventMetrics(GlobalMetrics):
@@ -46,10 +48,8 @@ class GeventMetrics(GlobalMetrics):
     def __iter__(self):
         hub = gevent.get_hub()
         threadpool, loop = hub.threadpool, hub.loop
-        yield 'gevent.threadpool.size', threadpool.size, {}
-        yield 'gevent.threadpool.maxsize', threadpool.maxsize, {}
-        yield 'gevent.active', loop.activecnt, {}
-        yield 'gevent.pending', loop.pendingcnt, {}
-        yield 'gevent.depth', loop.depth, {}
-
-
+        yield metrics.RawMetric('gevent.threadpool.size', threadpool.size)
+        yield metrics.RawMetric('gevent.threadpool.maxsize', threadpool.maxsize)
+        yield metrics.RawMetric('gevent.active', loop.activecnt)
+        yield metrics.RawMetric('gevent.pending', loop.pendingcnt)
+        yield metrics.RawMetric('gevent.depth', loop.depth)

--- a/lymph/core/monitoring/metrics.py
+++ b/lymph/core/monitoring/metrics.py
@@ -1,26 +1,48 @@
 import abc
+import collections
+
 import six
 
 
-class Metrics(object):
-    def __init__(self, **tags):
-        self.__metrics = []
-        self.tags = tags
+class RawMetric(object):
 
-    def add(self, metric):
-        self.__metrics.append(metric)
-
-    def add_tags(self, **tags):
-        self.tags.update(tags)
-
-    def __call__(self):
-        return iter(self)
+    def __init__(self, name, value, tags=None):
+        self._name = name
+        self._value = value
+        self._tags = tags or {}
 
     def __iter__(self):
-        for metrics in self.__metrics:
-            for name, value, tags in metrics():
-                tags.update(self.tags)
-                yield name, value, tags
+        yield (self._name, self._value, self._tags)
 
     def __repr__(self):
-        return '<%s tags=%r metrics=%r>' % (self.__class__.__name__, self.tags, self.__metrics)
+        return '%s(name=%r, value=%r, tags=%r)' % (
+            self.__class__.__name__,
+            self._name,
+            self._value,
+            self._tags)
+
+    __str__ = __repr__
+
+
+class Counter(RawMetric):
+
+    def __init__(self, name, tags=None):
+        super(Counter, self).__init__(name, 0, tags)
+
+    def __iadd__(self, value):
+        self._value += value
+        return self
+
+
+class TaggedCounter(RawMetric):
+
+    def __init__(self, name, tags=None):
+        super(TaggedCounter, self).__init__(name, collections.Counter(), tags)
+
+    def incr(self, _value=1, **tags):
+        tags.update(self._tags)
+        self._value[frozenset(tags.items())] += _value
+
+    def __iter__(self):
+        for tags, count in self._value.items():
+            yield self._name, count, dict(tags)

--- a/lymph/core/monitoring/pusher.py
+++ b/lymph/core/monitoring/pusher.py
@@ -6,7 +6,6 @@ import msgpack
 import zmq.green as zmq
 
 from lymph.core.components import Component
-from lymph.core.monitoring.metrics import Metrics
 from lymph.core.monitoring.global_metrics import RUsageMetrics, GeventMetrics, GarbageCollectionMetrics
 
 
@@ -17,7 +16,7 @@ DEFAULT_MONITOR_ENDPOINT = 'tcp://127.0.0.1:44044'
 
 
 class MonitorPusher(Component):
-    def __init__(self, container, endpoint=None, interval=2):
+    def __init__(self, container, aggregator, endpoint=None, interval=2):
         super(MonitorPusher, self).__init__()
         self.container = container
         self.interval = interval
@@ -27,14 +26,7 @@ class MonitorPusher(Component):
         self.socket = ctx.socket(zmq.PUB)
         self.socket.connect(self.endpoint)
 
-        self.aggregate = Metrics()
-        self.aggregate.add(RUsageMetrics())
-        self.aggregate.add(GarbageCollectionMetrics())
-        self.aggregate.add(GeventMetrics())
-        self.aggregate.add(container.metrics)
-
-    def add_tags(self, **tags):
-        self.aggregate.add_tags(**tags)
+        self.aggregator = aggregator
 
     def on_start(self):
         self.loop_greenlet = self.container.spawn(self.loop)
@@ -47,7 +39,7 @@ class MonitorPusher(Component):
         while True:
             gevent.sleep(self.interval)
             dt = time.monotonic() - last_stats
-            series = list(self.aggregate)
+            series = list(self.aggregator.get_metrics())
             stats = {
                 'time': time.time(),
                 'series': series,

--- a/lymph/tests/monitoring/test_aggregator.py
+++ b/lymph/tests/monitoring/test_aggregator.py
@@ -1,0 +1,37 @@
+import unittest
+
+from lymph.core.monitoring.metrics import RawMetric
+from lymph.core.monitoring.aggregator import Aggregator
+
+
+def _get_metrics_one(self):
+    yield RawMetric('dummy', 'one')
+
+
+def _get_metrics_two(self):
+    yield RawMetric('dummy', 'two')
+
+
+class AggregatorTestCase(object):
+
+    def test_aggregator_one_component(self):
+        aggr = Aggregator(_get_metrics_one, name='test')
+
+        self.assertEqual(list(aggr.get_metrics()), [('dummy', 'one', {'name': 'test'})])
+
+    def test_aggregator_multiple_components(self):
+        aggr = Aggregator(_get_metrics_one, _get_metrics_two, name='test')
+
+        self.assertEqual(list(aggr.get_metrics()), [
+            ('dummy', 'one', {'name': 'test'}),
+            ('dummy', 'two', {'name': 'test'}),
+        ])
+
+    def test_aggregator_add_multiple_tags(self):
+        aggr = Aggregator(_get_metrics_one, name='test')
+
+        aggr.add_tags(origin='localhost', time='now')
+
+        self.assertEqual(list(aggr.get_metrics()), [
+            ('dummy', 'one', {'name': 'test', 'origin': 'localhost', 'time': 'now'})
+        ])

--- a/lymph/tests/monitoring/test_metrics.py
+++ b/lymph/tests/monitoring/test_metrics.py
@@ -1,0 +1,69 @@
+import operator
+import unittest
+
+from lymph.core.monitoring import metrics
+
+
+class RawMetricsTest(unittest.TestCase):
+
+    def test_repr(self):
+        raw = metrics.RawMetric('raw', 'foobar', {})
+
+        self.assertEqual(repr(raw), "RawMetric(name='raw', value='foobar', tags={})")
+
+    def test_iter(self):
+        raw = metrics.RawMetric('raw', 'foobar', {})
+
+        self.assertEqual(list(raw), [('raw', 'foobar', {})])
+
+
+class CounterMetricsTest(unittest.TestCase):
+
+    def test_get(self):
+        counter = metrics.Counter('requests')
+
+        self.assertEqual(list(counter), [('requests', 0, {})])
+
+    def test_repr(self):
+        counter = metrics.Counter('requests')
+
+        self.assertEqual(str(counter), repr(counter))
+        self.assertEqual(repr(counter), "Counter(name='requests', value=0, tags={})")
+
+    def test_increment_by_one(self):
+        counter = metrics.Counter('requests')
+        counter += 1
+
+        self.assertEqual(list(counter), [('requests', 1, {})])
+
+    def test_increment_by_many(self):
+        counter = metrics.Counter('requests')
+        counter += 66
+
+        self.assertEqual(list(counter), [('requests', 66, {})])
+
+
+class TaggedCounterMetricsTest(unittest.TestCase):
+
+    def test_incr_one_type(self):
+        error_counter = metrics.TaggedCounter('exception')
+
+        error_counter.incr(type='ValueError')
+        error_counter.incr(4, type='ValueError')
+
+        self.assertEqual(list(error_counter), [
+            ('exception', 5, {'type': 'ValueError'})])
+
+    def test_incr_different_types(self):
+        error_counter = metrics.TaggedCounter('exception')
+
+        error_counter.incr(type='ValueError')
+        error_counter.incr(type='ValueError')
+
+        error_counter.incr(type='Nack')
+
+        self.assertEqual(
+            sorted(error_counter, key=operator.itemgetter(1)), [
+                ('exception', 1, {'type': 'Nack'}),
+                ('exception', 2, {'type': 'ValueError'}),
+            ])

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27,py34,docs
 
 [testenv]
+usedevelop = True
 install_command = pip install {opts} {packages}
 # workaround for test discovery issues (nose + py.test):
 changedir = {envtmpdir}


### PR DESCRIPTION
Refactor metrics and add new out of the box metrics classes
    
Split Metrics class into an Aggregator and RawMetric/Counter/NamespaceCounter
metric data holders, replace the tree-like behavior of Metrics class for each
component to a simple _get_metrics method in each component and python super(...).