### PR TITLE
Update RequsetHandler

### DIFF
--- a/lymph/web/handlers.py
+++ b/lymph/web/handlers.py
@@ -1,4 +1,3 @@
-import codecs
 import json
 
 from werkzeug.exceptions import MethodNotAllowed
@@ -23,8 +22,7 @@ class RequestHandler(object):
             raise ValueError("The request Content-Type is not JSON")
 
         if self._json is None:
-            reader = codecs.getreader(self.request.charset)
-            self._json = json.load(reader(self.request.stream))
+            self._json = json.loads(self.request.get_data(as_text=True))
         return self._json
 
     def dispatch(self, args):


### PR DESCRIPTION
Make use of werkzeug request.get_data in json method. Wekrzeug
handles charset and does caching for us.

As long as method verifies mimetype is json the method is
safe from messing with form data.