### PR TITLE
Remove 'class' from instance_config dict only if key exists

### DIFF
--- a/lymph/config.py
+++ b/lymph/config.py
@@ -51,7 +51,7 @@ class ConfigObject(collections.Mapping):
             return cls.from_config(instance_config, **kwargs)
         else:
             instance_config = copy.deepcopy(dict(instance_config))
-            del instance_config['class']
+            instance_config.pop('class', None)
             instance_config.update(kwargs)
             return cls(**instance_config)
 


### PR DESCRIPTION
This will avoid raising KeyError if 'class' is not a key of instance_config dict.