### PR TITLE
Add a new method assert_any_rpc_calls

### DIFF
--- a/docs/api/testings_api.rst
+++ b/docs/api/testings_api.rst
@@ -75,6 +75,18 @@ Testings API
      ``mock.call(..)`` can contain `PyHamcrest`_ matchers for better and less brittle
      tests.
 
+  .. method:: assert_any_rpc_calls(*expected_calls)
+
+    At the opposite of ``assert_rpc_calls`` where you have to specify
+    all mocked calls that were done, this method accept a list of mocked calls and
+    assert that each one of them was done. The calls should be specified in the same
+    order as they are made.
+
+    .. note::
+
+      This method do it's best to guess which function user is looking for and in
+      case of a mismatch it try to generate a useful message for the user.
+
 
 .. class:: EventMockTestCase
 

--- a/lymph/tests/test_mock_helpers.py
+++ b/lymph/tests/test_mock_helpers.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 import mock
@@ -22,25 +23,46 @@ class RPCMockHelperTests(unittest.TestCase):
             [mock.call('func', 1, foo='bar')]
         )
 
+    def test_single_call_different_name(self):
+        with self.assertRaisesRegexp(AssertionError, "function #0 name doesn't match, expected 'func2' actual 'func1'"):
+            self.dummy_case._assert_equal_calls(
+                [mock.call('func1', 1)],
+                [mock.call('func2', 1)]
+            )
+
     def test_single_call_args_mismatch(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegexp(AssertionError, re.compile("function #0 argument #0 doesn't match.*", re.DOTALL)):
             self.dummy_case._assert_equal_calls(
                 [mock.call('func', 1, foo='bar')],
                 [mock.call('func', 102, foo='bar')]
             )
 
     def test_single_call_keyword_value_mismatch(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegexp(AssertionError, re.compile("function #0 keyword argument 'foo' doesn't match.*", re.DOTALL)):
             self.dummy_case._assert_equal_calls(
                 [mock.call('func', 1, foo='foobar')],
                 [mock.call('func', 1, foo='bar')]
             )
 
     def test_single_call_keyword_name_mismatch(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegexp(AssertionError, "function #0 keyword arguments doesn't match, expected \['something'\] actual \['foo'\]"):
             self.dummy_case._assert_equal_calls(
                 [mock.call('func', 1, foo='bar')],
-                [mock.call('func', 1, somthing='bar')]
+                [mock.call('func', 1, something='bar')]
+            )
+
+    def test_single_call_keyword_different_count(self):
+        with self.assertRaisesRegexp(AssertionError, "function #0 keyword arguments doesn't match, expected \['bar', 'foo'\] actual \['foo'\]"):
+            self.dummy_case._assert_equal_calls(
+                [mock.call('func', 1, foo='bar')],
+                [mock.call('func', 1, foo='bar', bar='taz')]
+            )
+
+    def test_single_call_argument_different_count(self):
+        with self.assertRaisesRegexp(AssertionError, "function #0 arguments count doesn't match, expected 1 actual 2"):
+            self.dummy_case._assert_equal_calls(
+                [mock.call('func', 1, 2)],
+                [mock.call('func', 1)]
             )
 
     def test_multiple_call_match(self):
@@ -56,3 +78,78 @@ class RPCMockHelperTests(unittest.TestCase):
                 mock.call('func', 3, foo='foobar')
             ],
         )
+
+    def test_assert_equal_any_call_success(self):
+        self.dummy_case._assert_equal_any_calls(
+            [
+                mock.call('func1', 1, foo='foo'),
+                mock.call('func2', 2, foo='bar'),
+                mock.call('func3', 3, foo='foobar')
+            ],
+            [
+                mock.call('func2', 2, foo='bar'),
+                mock.call('func3', 3, foo='foobar')
+            ],
+        )
+
+    def test_assert_equal_any_call_success_with_no_expect(self):
+        self.dummy_case._assert_equal_any_calls(
+            [
+                mock.call('func1', 1, foo='foo'),
+                mock.call('func2', 2, foo='bar'),
+                mock.call('func3', 3, foo='foobar')
+            ],
+            [],
+        )
+
+    def test_assert_equal_any_call_fail_with_possible_matches(self):
+        with self.assertRaisesRegexp(AssertionError, "Call 'call\('func10', 3, foo='foobar'\)' wasn't found."):
+            self.dummy_case._assert_equal_any_calls(
+                [
+                    mock.call('func1', 1, foo='foo'),
+                    mock.call('func2', 2, foo='bar'),
+                    mock.call('func3', 3, foo='foobar')
+                ],
+                [
+                    mock.call('func10', 3, foo='foobar')
+                ],
+            )
+
+    def test_assert_equal_any_call_fail_with_no_match(self):
+        with self.assertRaisesRegexp(AssertionError, re.compile("Call 'call\('func2', 3, foo='foo'\)' wasn't found. Maybe you want:.*?", re.DOTALL)):
+            self.dummy_case._assert_equal_any_calls(
+                [
+                    mock.call('func2', 1, foo='foo'),
+                    mock.call('func2', 2, foo='bar'),
+                    mock.call('func2', 3, foo='foobar')
+                ],
+                [
+                    mock.call('func2', 3, foo='foo')
+                ],
+            )
+
+    def test_assert_equal_any_call_fail_with_no_match_better_message(self):
+        with self.assertRaisesRegexp(AssertionError, re.compile("function #0 keyword argument 'foo' doesn't match*?", re.DOTALL)):
+            self.dummy_case._assert_equal_any_calls(
+                [
+                    mock.call('func1', 2, foo='bar'),
+                    mock.call('func2', 3, foo='foobar')
+                ],
+                [
+                    mock.call('func2', 3, foo='foo')
+                ],
+            )
+
+    def test_assert_equal_any_call_fail_with_wrong_order(self):
+        with self.assertRaisesRegexp(AssertionError, re.compile("Call 'call\('func2', 2, foo='bar'\)' wasn't found.", re.DOTALL)):
+            self.dummy_case._assert_equal_any_calls(
+                [
+                    mock.call('func1', 1, foo='foo'),
+                    mock.call('func2', 2, foo='bar'),
+                    mock.call('func3', 3, foo='foobar')
+                ],
+                [
+                    mock.call('func3', 3, foo='foobar'),
+                    mock.call('func2', 2, foo='bar')
+                ],
+            )


### PR DESCRIPTION
This can be useful when we only one to check for a subset of mock.calls, this
method like it's sibling try to generate the best error message by guessing
what user want to test for.