### PR TITLE
Make serial events compatible with python3

### DIFF
--- a/lymph/patterns/serial_events.py
+++ b/lymph/patterns/serial_events.py
@@ -63,7 +63,7 @@ class SerialEventHandler(Component):
         return '%s.%s' % (self.consumer_func.__name__, index)
 
     def push(self, interface, event):
-        key = str(self.key(interface, event))
+        key = str(self.key(interface, event)).encode('utf-8')
         index = int(hashlib.md5(key).hexdigest(), 16) % self.partition_count
         logger.debug('PUBLISH %s %s', self.get_queue_name(index), event)
         self.interface.emit(self.get_queue_name(index), {'event': event.serialize()})


### PR DESCRIPTION
This PR will fix encoding issue on python3 with key hashing

Example of traceback:
```
 vi +301 /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/dhh/flow/tests/test_orders.py  # test_happy_path
    self.emit('order.created', {'pk': 11})
  vi +228 /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/lymph/testing/__init__.py  # emit
    return self.container.emit_event(*args, **kwargs)
  vi +178 /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/lymph/core/container.py  # emit_event
    self.event_system.emit(event, **kwargs)
  vi +23  /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/lymph/events/local.py  # emit
    self.dispatcher(event)
  vi +116 /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/lymph/core/events.py  # __call__
    handler(event)
  vi +74  /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/lymph/core/events.py  # __call__
    return self.func(self.interface, event, *args, **kwargs)
  vi +67  /Users/andreybilunyk/Dev/dhh/dhh-flow-orders/.tox/py34/lib/python3.4/site-packages/lymph/patterns/serial_events.py  # push
    index = int(hashlib.md5(key).hexdigest(), 16) % self.partition_count
TypeError: Unicode-objects must be encoded before hashing
```