### PR TITLE
get_empty_kwargs need to be override as doc[1] say

### DIFF
--- a/lymph/web/routing.py
+++ b/lymph/web/routing.py
@@ -6,3 +6,9 @@ class HandledRule(Rule):
     def __init__(self, string, handler, **kwargs):
         self.handler = handler
         super(HandledRule, self).__init__(string, **kwargs)
+
+    def get_empty_kwargs(self):
+        empty_kwargs = super(HandledRule, self).get_empty_kwargs()
+        empty_kwargs['handler'] = self.handler
+        return empty_kwargs
+


### PR DESCRIPTION
With this we can use HandledRule with Submount and EndpointPrefix and so on.

[1]: http://werkzeug.pocoo.org/docs/0.10/routing/#werkzeug.routing.Rule.empty