### PR TITLE
Event broadcast

### DIFF
--- a/lymph/core/events.py
+++ b/lymph/core/events.py
@@ -43,7 +43,7 @@ class Event(object):
 
 class EventHandler(Component):
     def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True, once=False, broadcast=False):
-        assert (not (once and broadcast)), ("Once and broadcast cannot be enabled at the same time")
+        assert not (once and broadcast), "Once and broadcast cannot be enabled at the same time"
         super(EventHandler, self).__init__()
         self.func = func
         self.event_types = event_types

--- a/lymph/core/events.py
+++ b/lymph/core/events.py
@@ -1,7 +1,6 @@
 import re
 import logging
 from uuid import uuid4
-
 from lymph.core.interfaces import Component
 from lymph.core import trace
 
@@ -43,8 +42,8 @@ class Event(object):
 
 
 class EventHandler(Component):
-    def __init__(self, interface, func, event_types, sequential=False,
-                 queue_name=None, active=True, once=False, broadcast=False):
+    def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True, once=False, broadcast=False):
+        assert (not (once and broadcast)), ("Once and broadcast cannot be enabled at the same time")
         super(EventHandler, self).__init__()
         self.func = func
         self.event_types = event_types
@@ -117,4 +116,3 @@ class EventDispatcher(object):
                 handlers.add(handler)
                 handler(event)
         return bool(handlers)
-

--- a/lymph/core/events.py
+++ b/lymph/core/events.py
@@ -43,7 +43,8 @@ class Event(object):
 
 
 class EventHandler(Component):
-    def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True, once=False):
+    def __init__(self, interface, func, event_types, sequential=False,
+                 queue_name=None, active=True, once=False, broadcast=False):
         super(EventHandler, self).__init__()
         self.func = func
         self.event_types = event_types
@@ -51,7 +52,7 @@ class EventHandler(Component):
         self.active = active
         self.interface = interface
         self.once = once
-        self.unique_key = str(uuid4()) if once else None
+        self.unique_key = str(uuid4()) if once or broadcast else None
         self._queue_name = queue_name or func.__name__
 
     @property

--- a/lymph/core/events.py
+++ b/lymph/core/events.py
@@ -52,6 +52,7 @@ class EventHandler(Component):
         self.active = active
         self.interface = interface
         self.once = once
+        self.broadcast = broadcast
         self.unique_key = str(uuid4()) if once or broadcast else None
         self._queue_name = queue_name or func.__name__
 

--- a/lymph/events/kombu.py
+++ b/lymph/events/kombu.py
@@ -96,7 +96,12 @@ class KombuEventSystem(BaseEventSystem):
     def setup_consumer(self, handler):
         with self._get_connection() as conn:
             self.exchange(conn).declare()
-            queue = kombu.Queue(handler.queue_name, durable=True, auto_delete=handler.once)
+            if handler.broadcast:
+                queue = kombu.Queue(handler.queue_name, exclusive=True,
+                                    durable=False)
+            else:
+                queue = kombu.Queue(handler.queue_name, durable=True,
+                                    auto_delete=handler.once)
             queue(conn).declare()
             for event_type in handler.event_types:
                 queue(conn).bind_to(exchange=self.exchange, routing_key=event_type)

--- a/lymph/events/kombu.py
+++ b/lymph/events/kombu.py
@@ -97,11 +97,9 @@ class KombuEventSystem(BaseEventSystem):
         with self._get_connection() as conn:
             self.exchange(conn).declare()
             if handler.broadcast:
-                queue = kombu.Queue(handler.queue_name, exclusive=True,
-                                    durable=False)
+                queue = kombu.Queue(handler.queue_name, exclusive=True, durable=False)
             else:
-                queue = kombu.Queue(handler.queue_name, durable=True,
-                                    auto_delete=handler.once)
+                queue = kombu.Queue(handler.queue_name, durable=True, auto_delete=handler.once)
             queue(conn).declare()
             for event_type in handler.event_types:
                 queue(conn).bind_to(exchange=self.exchange, routing_key=event_type)

--- a/lymph/tests/integration/test_kombu_events.py
+++ b/lymph/tests/integration/test_kombu_events.py
@@ -37,14 +37,14 @@ class KombuIntegrationTest(LymphIntegrationTestCase, AsyncTestsMixin):
         self.exchange_name = 'test-%s' % uuid.uuid4()
         self.discovery_hub = StaticServiceRegistryHub()
 
-        self.the_container1, self.the_interface1 = self.create_container(TestInterface, 'test')
-        self.lymph_client1 = self.create_client()
+        self.the_container_unicast, self.the_interface_unicast = self.create_container(TestInterface, 'test')
+        self.lymph_client_unicast = self.create_client()
 
-        self.the_container2, self.the_interface2 = self.create_container(TestEventBroadcastInterface, 'test')
-        self.lymph_client2 = self.create_client()
+        self.the_container_emitter, self.the_interface_emitter = self.create_container(TestEventBroadcastInterface, 'test')
+        self.lymph_client_emitter = self.create_client()
 
-        self.the_container3, self.the_interface3= self.create_container(TestEventBroadcastInterface, 'test')
-        self.lymph_client3 = self.create_client()
+        self.the_container_receiver, self.the_interface_receiver = self.create_container(TestEventBroadcastInterface, 'test')
+        self.create_client()
 
 
     def tearDown(self):
@@ -73,27 +73,27 @@ class KombuIntegrationTest(LymphIntegrationTestCase, AsyncTestsMixin):
 
     def received_check(self, n):
         def check():
-            return len(self.the_interface1.collected_events) == n
+            return len(self.the_interface_unicast.collected_events) == n
         return check
 
     def received_broadcast_check(self, n):
         def check():
-            return (len(self.the_interface2.collected_events) + len(self.the_interface3.collected_events)) == n
+            return (len(self.the_interface_emitter.collected_events) + len(self.the_interface_receiver.collected_events)) == n
         return check
 
     def test_emit(self):
-        self.lymph_client1.emit('foo', {})
+        self.lymph_client_unicast.emit('foo', {})
         self.assert_eventually_true(self.received_check(1), timeout=2)
-        self.assertEqual(self.the_interface1.collected_events[0].evt_type, 'foo')
+        self.assertEqual(self.the_interface_unicast.collected_events[0].evt_type, 'foo')
 
     def test_delayed_emit(self):
-        self.lymph_client1.emit('foo', {}, delay=.5)
+        self.lymph_client_unicast.emit('foo', {}, delay=.5)
         self.assert_temporarily_true(self.received_check(0), timeout=.2)
         self.assert_eventually_true(self.received_check(1), timeout=.5)
-        self.assertEqual(self.the_interface1.collected_events[0].evt_type, 'foo')
+        self.assertEqual(self.the_interface_unicast.collected_events[0].evt_type, 'foo')
 
     def test_broadcast_event(self):
-        self.lymph_client2.emit('foo_broadcast', {})
+        self.lymph_client_emitter.emit('foo_broadcast', {})
         self.assert_eventually_true(self.received_broadcast_check(2), timeout=2)
-        self.assertEqual(self.the_interface2.collected_events[0].evt_type, 'foo_broadcast')
-        self.assertEqual(self.the_interface3.collected_events[0].evt_type, 'foo_broadcast')
+        self.assertEqual(self.the_interface_receiver.collected_events[0].evt_type, 'foo_broadcast')
+        self.assertEqual(self.the_interface_emitter.collected_events[0].evt_type, 'foo_broadcast')


### PR DESCRIPTION
Event broadcast allows multiple event's consumers to consume the same event and carry out concurrent tasks when an event is fired. We need it for multiple web-socket servers.  
Example:
```
@lymph.event('uppercase_transform_finished', broadcast=True)
 def on_uppercase(self, event):

```
