### PR TITLE
Use autodelete instead of exclusive 

### DIFF
--- a/lymph/events/kombu.py
+++ b/lymph/events/kombu.py
@@ -10,6 +10,7 @@ import kombu.pools
 
 from lymph.events.base import BaseEventSystem
 from lymph.core.events import Event
+from lymph.utils.logging import setup_logger
 
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,9 @@ class KombuEventSystem(BaseEventSystem):
         self.serializer = serializer
         self.consumers_by_queue = {}
 
+    def on_start(self):
+        setup_logger('kombu')
+
     def on_stop(self, **kwargs):
         for consumer in self.consumers_by_queue.values():
             consumer.stop(**kwargs)
@@ -97,7 +101,7 @@ class KombuEventSystem(BaseEventSystem):
         with self._get_connection() as conn:
             self.exchange(conn).declare()
             if handler.broadcast:
-                queue = kombu.Queue(handler.queue_name, exclusive=True, durable=False)
+                queue = kombu.Queue(handler.queue_name, auto_delete=True, durable=False)
             else:
                 queue = kombu.Queue(handler.queue_name, durable=True, auto_delete=handler.once)
             queue(conn).declare()

--- a/lymph/testing/__init__.py
+++ b/lymph/testing/__init__.py
@@ -124,6 +124,7 @@ class LymphIntegrationTestCase(KazooTestHarness):
             container.join()
         if self.use_zookeeper:
             self.teardown_zookeeper()
+        self._containers = []
 
     def create_client(self, **kwargs):
         container, interface = self.create_container(**kwargs)

--- a/lymph/tests/integration/test_kombu_events.py
+++ b/lymph/tests/integration/test_kombu_events.py
@@ -46,7 +46,7 @@ class KombuIntegrationTest(LymphIntegrationTestCase, AsyncTestsMixin):
         self.lymph_client = self.create_client()
 
     def tearDown(self):
-        super(LymphIntegrationTestCase, self).tearDown()
+        super(KombuIntegrationTest, self).tearDown()
         connection = self.get_kombu_connection()
         exchange = kombu.Exchange(self.exchange_name)
         exchange(connection).delete()
@@ -81,17 +81,17 @@ class KombuIntegrationTest(LymphIntegrationTestCase, AsyncTestsMixin):
 
     def test_emit(self):
         self.lymph_client.emit('foo', {})
-        self.assert_eventually_true(self.received_check(1), timeout=2)
+        self.assert_eventually_true(self.received_check(1), timeout=10)
         self.assertEqual(self.the_interface.collected_events[0].evt_type, 'foo')
 
     def test_delayed_emit(self):
         self.lymph_client.emit('foo', {}, delay=.5)
         self.assert_temporarily_true(self.received_check(0), timeout=.2)
-        self.assert_eventually_true(self.received_check(1), timeout=.5)
+        self.assert_eventually_true(self.received_check(1), timeout=10)
         self.assertEqual(self.the_interface.collected_events[0].evt_type, 'foo')
 
     def test_broadcast_event(self):
         self.lymph_client.emit('foo_broadcast', {})
-        self.assert_eventually_true(self.received_broadcast_check(2), timeout=2)
+        self.assert_eventually_true(self.received_broadcast_check(2), timeout=10)
         self.assertEqual(self.the_interface.collected_events[0].evt_type, 'foo_broadcast')
         self.assertEqual(self.the_interface_broadcast.collected_events[0].evt_type, 'foo_broadcast')


### PR DESCRIPTION
Small timeouts were given us a lot of negative failures.