### PR TITLE
Correctly forward trace_ids

### DIFF
--- a/lymph/cli/request.py
+++ b/lymph/cli/request.py
@@ -10,6 +10,7 @@ import time
 from gevent.pool import Pool
 
 from lymph.client import Client
+from lymph.core import trace
 from lymph.exceptions import Timeout
 from lymph.cli.base import Command, handle_request_errors
 
@@ -102,6 +103,7 @@ class RequestCommand(Command):
         client = Client.from_config(self.config)
 
         def request():
+            trace.set_id()
             return client.request(address, subject, body, timeout=timeout)
 
         N, C = int(self.args['-N']), int(self.args['-C'])

--- a/lymph/core/rpc.py
+++ b/lymph/core/rpc.py
@@ -186,6 +186,7 @@ class ZmqRPCServer(Component):
     def dispatch_request(self, msg):
         loglevel = self._get_loglevel(msg)
         logger.log(loglevel, '%s source=%s', msg.subject, msg.source)
+        trace.set_id(msg.headers.get('trace_id'))
         start = time.time()
         self.request_counts.incr(subject=msg.subject)
         channel = ReplyChannel(msg, self)


### PR DESCRIPTION
The trace_id was extracted from incoming requests only before
spawning the new greenlet to handle the request. The new greenlet
then had no trace_id set and log messages would not be annotated
with the correct trace_id.

Also made `lymph request` generate trace_ids.