### PR TITLE
apply empty config for interface in instance command

### DIFF
--- a/lymph/cli/service.py
+++ b/lymph/cli/service.py
@@ -80,7 +80,8 @@ class InstanceCommand(Command):
 
         for cls_name in self.args.get('--interface', ()):
             cls = import_object(cls_name)
-            self.container.install_interface(cls)
+            instance = self.container.install_interface(cls)
+            instance.apply_config({})
 
     def _start_backdoor_terminal(self):
         # XXX(Mouad): Imported here since this is still broken in Python3.x


### PR DESCRIPTION
Call `apply_config` specified interface on in `lymph-instance` command, e.g.:

```
lymph instance --interface=examples.echo:Echo
```