### PR TITLE
Allowing installation of multiple interfaces using the same factory

### DIFF
--- a/lymph/core/container.py
+++ b/lymph/core/container.py
@@ -102,7 +102,8 @@ class ServiceContainer(Componentized):
         return self.server.identity
 
     def install_interface(self, cls, **kwargs):
-        interface = self.install(cls, **kwargs)
+        interface = cls(self, **kwargs)
+        self.add_component(interface)
         self.installed_interfaces[interface.name] = interface
         for plugin in self.installed_plugins:
             plugin.on_interface_installation(interface)


### PR DESCRIPTION
This allows us to install multiple interfaces using the same class but different name.

eg.

```yaml
interfaces:
    foo:
         class: interfaces:FooInterface
    bar:
         class: interfaces:FooInterace
         spam: bar
```