### PR TITLE
set process title after registering

### DIFF
--- a/lymph/cli/service.py
+++ b/lymph/cli/service.py
@@ -63,9 +63,9 @@ class InstanceCommand(Command):
 
         self._register_signals()
 
-        self._set_process_title()
-
         self.container.start(register=not self.args.get('--isolated', False))
+
+        self._set_process_title()
 
         if self.args.get('--reload'):
             set_source_change_callback(self.container.stop)


### PR DESCRIPTION
Before:

    lymph-instance (identity: None, endpoint: None, config: ./config.yml)

After:

    lymph-instance (identity: 9e757f2118ae87d4702b6b483263d199, endpoint: tcp://10.13.220.99:64669, config: ./config.yml)