### PR TITLE
Don't fail when machine go to sleep

### DIFF
--- a/lymph/discovery/zookeeper.py
+++ b/lymph/discovery/zookeeper.py
@@ -124,6 +124,14 @@ class ZookeeperServiceRegistry(BaseServiceRegistry):
         path = self._get_zk_path(service_name, instance.identity)
         value = json.dumps(instance.serialize())
 
+        # XXX(Mouad): In case path already exist delete it before registering,
+        # this is protecting mechanism for when dev machine go to sleep or service
+        # restart too fast (before zookeeper detect service is gone).
+        try:
+            self.client.delete(path)
+        except NoNodeError:
+            pass
+
         result = self.client.create_async(
             path,
             value.encode('utf-8'),


### PR DESCRIPTION
If dev machine go to sleep (lymph instance and zookeeper in same machine) as
soon as machine is back lymph will try to re-register instance with Zookeeper
which may fail with NodeExistsError if zookeeper also went to sleep and this later
didn't get the chance to detect broken connection and delete ephemeral node.