### PR TITLE
Better process metrics

### DIFF
--- a/lymph/core/monitoring/aggregator.py
+++ b/lymph/core/monitoring/aggregator.py
@@ -1,5 +1,5 @@
 from lymph.core.monitoring.metrics import Aggregate
-from lymph.core.monitoring.global_metrics import RUsageMetrics, GeventMetrics, GarbageCollectionMetrics
+from lymph.core.monitoring.global_metrics import RUsageMetrics, GeventMetrics, GarbageCollectionMetrics, ProcessMetrics
 
 
 class Aggregator(Aggregate):
@@ -11,4 +11,5 @@ class Aggregator(Aggregate):
             RUsageMetrics(),
             GarbageCollectionMetrics(),
             GeventMetrics(),
+            ProcessMetrics(),
         ], tags=tags)

--- a/lymph/tests/monitoring/test_global_metrics.py
+++ b/lymph/tests/monitoring/test_global_metrics.py
@@ -1,0 +1,16 @@
+import unittest
+
+from lymph.core.monitoring.global_metrics import ProcessMetrics
+
+
+class GlobalMetricsTests(unittest.TestCase):
+    def setUp(self):
+        self.process_metrics = ProcessMetrics()
+
+    def test_process_metrics(self):
+        metric_names = [m[0] for m in self.process_metrics]
+
+        self.assertIn('proc.files.count', metric_names)
+        self.assertIn('proc.threads.count', metric_names)
+        self.assertIn('proc.mem.rss', metric_names)
+        self.assertIn('proc.cpu.system', metric_names)


### PR DESCRIPTION
Use psutil to generate process global metrics e.g. cpu/memory/files/io ... .

The problem with rusage is that it's too low level, hard to understand and also
sometimes hard to use since it depend on the platform example:

maxrss which is in kilobytes in Lunix and bytes in OSX.
    - http://man7.org/linux/man-pages/man2/getrusage.2.html
    - https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getrusage.2.html

This new process metric aim to give more fine grain and understandable metrics.