### PR TITLE
Accept request body from stdin

### DIFF
--- a/lymph/cli/request.py
+++ b/lymph/cli/request.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 class RequestCommand(Command):
     """
-    Usage: lymph request [options] <subject> <params>
+    Usage: lymph request [options] <subject> <params> [-]
 
     Description:
         Sends a single RPC request to <address>. Parameters have to be JSON encoded.
@@ -90,7 +90,10 @@ class RequestCommand(Command):
 
     @handle_request_errors
     def run(self):
-        body = json.loads(self.args.get('<params>', '{}'))
+        params = self.args.get('<params>')
+        if params == '-':
+            params = sys.stdin.read()
+        body = json.loads(params)
         try:
             timeout = float(self.args.get('--timeout'))
         except ValueError:
@@ -113,4 +116,3 @@ class RequestCommand(Command):
             return self._run_one_request(request)
         else:
             return self._run_many_requests(request, N, C)
-


### PR DESCRIPTION
When body is too big usually you will have it in a file a pretty version
that you will edit and in that case it way easier to do:

    cat body.json | lymph request service.func -

Than the alternative which is copy-paste.