### PR TITLE
Not found hook for web interfaces

### DIFF
--- a/lymph/tests/integration/test_web_interface.py
+++ b/lymph/tests/integration/test_web_interface.py
@@ -1,3 +1,4 @@
+from werkzeug.exceptions import NotFound, MethodNotAllowed
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Response
 
@@ -17,10 +18,22 @@ class HandledRuleHandler(RequestHandler):
         return Response("Handled Rule Handler")
 
 
+class CustomNotFound(NotFound):
+    def __init__(self):
+        response = Response("never-gonna-match-you-down", status=404)
+        super(CustomNotFound, self).__init__(response=response)
+
+
+class CustomMethodNotAllowed(MethodNotAllowed):
+    def get_body(self, *args, **kwargs):
+        return "never-gonna-run-around-or-post-you"
+
+
 class Web(WebServiceInterface):
     url_map = Map([
         Rule("/test/", endpoint="test"),
-        Rule("/foo/", endpoint=RuleHandler),
+        Rule("/foo/", endpoint=RuleHandler, methods=['get']),
+        Rule("/baz/", endpoint=RuleHandler),
         HandledRule("/bar/", endpoint="bar", handler=HandledRuleHandler),
         Rule("/fail/", endpoint="fail"),
         Rule("/fail-wrong-endpoint/", endpoint=42),
@@ -28,6 +41,11 @@ class Web(WebServiceInterface):
 
     def test(self, request):
         return Response("method test")
+
+
+class CustomErrorHandlingWeb(Web):
+    NotFound = CustomNotFound
+    MethodNotAllowed = CustomMethodNotAllowed
 
 
 class WebIntegrationTest(WebServiceTestCase):
@@ -58,3 +76,40 @@ class WebIntegrationTest(WebServiceTestCase):
         response = self.client.get("/fail-wrong-endpoint/")
         self.assertEqual(response.data.decode("utf8"), "")
         self.assertEqual(response.status_code, 500)
+
+    def test_dispatch_not_found(self):
+        response = self.client.get("/never-gonna-match-me-up/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_dispatch_methond_not_allowed(self):
+        response = self.client.post("/bar/")
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.post("/foo/")
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.post("/baz/")
+        self.assertEqual(response.status_code, 405)
+
+
+class CustomErrorHandlingWebIntegrationTest(WebIntegrationTest):
+
+    service_class = CustomErrorHandlingWeb
+
+    def test_dispatch_not_found(self):
+        response = self.client.get("/never-gonna-match-me-up/")
+        self.assertEqual(response.data.decode("utf8"), "never-gonna-match-you-down")
+        self.assertEqual(response.status_code, 404)
+
+    def test_dispatch_methond_not_allowed(self):
+        response = self.client.post("/bar/")
+        self.assertEqual(response.data.decode("utf8"), "never-gonna-run-around-or-post-you")
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.post("/foo/")
+        self.assertEqual(response.data.decode("utf8"), "never-gonna-run-around-or-post-you")
+        self.assertEqual(response.status_code, 405)
+
+        response = self.client.post("/baz/")
+        self.assertEqual(response.data.decode("utf8"), "never-gonna-run-around-or-post-you")
+        self.assertEqual(response.status_code, 405)

--- a/lymph/web/handlers.py
+++ b/lymph/web/handlers.py
@@ -13,10 +13,6 @@ class RequestHandler(object):
         self.interface = interface
         self._json = None
 
-    @property
-    def allowed_methods(self):
-        return [method.upper() for method in http_methods if callable(getattr(self, method, None))]
-
     def json(self):
         if not "application/json" == self.request.mimetype:
             raise ValueError("The request Content-Type is not JSON")
@@ -28,9 +24,9 @@ class RequestHandler(object):
     def dispatch(self, args):
         method = self.request.method.lower()
         if method not in http_methods:
-            raise MethodNotAllowed(self.allowed_methods)
+            raise MethodNotAllowed()
         try:
             func = getattr(self, method)
         except AttributeError:
-            raise MethodNotAllowed(self.allowed_methods)
+            raise MethodNotAllowed()
         return func(**args)


### PR DESCRIPTION
Update web interfaces. Add a not found hook that interfaces can overwrite. This can be useful when http interfaces that want to stick to unified response content type different than html
