### PR TITLE
Retryable event handling

### DIFF
--- a/lymph/core/events.py
+++ b/lymph/core/events.py
@@ -43,7 +43,7 @@ class Event(object):
 
 
 class EventHandler(Component):
-    def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True, once=False, broadcast=False):
+    def __init__(self, interface, func, event_types, sequential=False, queue_name=None, active=True, once=False, broadcast=False, retry=0):
         assert not (once and broadcast), "Once and broadcast cannot be enabled at the same time"
         super(EventHandler, self).__init__()
         self.func = func
@@ -54,6 +54,7 @@ class EventHandler(Component):
         self.once = once
         self.broadcast = broadcast
         self.unique_key = str(uuid4()) if once or broadcast else None
+        self.retry = retry
         self._queue_name = queue_name or func.__name__
 
     @property

--- a/lymph/tests/integration/test_kombu_events.py
+++ b/lymph/tests/integration/test_kombu_events.py
@@ -17,6 +17,11 @@ class TestInterface(lymph.Interface):
     def on_foo(self, event):
         self.collected_events.append(event)
 
+    @lymph.event('retryable_foo', retry=2)
+    def on_retryable_foo(self, event):
+        self.collected_events.append(event)
+        raise Exception()
+
     @lymph.event('foo_broadcast', broadcast=True)
     def on_foo_broadcast(self, event):
         self.collected_events.append(event)
@@ -94,3 +99,7 @@ class KombuIntegrationTest(LymphIntegrationTestCase, AsyncTestsMixin):
         self.assert_eventually_true(self.received_broadcast_check(2), timeout=10)
         self.assertEqual(self.the_interface.collected_events[0].evt_type, 'foo_broadcast')
         self.assertEqual(self.the_interface_broadcast.collected_events[0].evt_type, 'foo_broadcast')
+
+    def test_retryable_event(self):
+        self.lymph_client.emit('retryable_foo', {})
+        self.assert_eventually_true(self.received_check(3), timeout=10)


### PR DESCRIPTION
Add a retry option to ``lymph.event(...)`` that specify max number of
reties to do in case an exception is raised when handling the given event.
The way retry work is by republishing the event to the handler queue while setting
a header that specify the number of reties left, this way of requeuing an event
at the opposite to ``message.reject(requeue=True)`` enable us to set a limit of the
numbers of retries.

Note: This feature should only be used when the event handler is guarantee to be idempotent.