### PR TITLE
Add ability to change runtime log level

### DIFF
--- a/lymph/cli/loglevel.py
+++ b/lymph/cli/loglevel.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+
+from lymph.client import Client
+from lymph.cli.base import Command, handle_request_errors
+
+
+class LogLevelCommand(Command):
+    """
+    Usage: lymph change-loglevel <address> [options]
+
+    Sets the log level of a service's logger (all instances) for a given amount of time and then resets.
+
+    Options:
+      --name=<name>, -n            Logger name to change.
+      --level=<level>, -l          Logging level to use.
+      --period=<seconds>, -p       Period where change will be effected, after
+                                   the logging level will be reverted [default: 60]
+      --guess-external-ip, -g      Guess the public facing IP of this machine and
+                                   use it instead of the provided address.
+
+    {COMMON_OPTIONS}
+    """
+
+    short_description = 'Set logging level of a service logger'
+
+    @handle_request_errors
+    def run(self):
+        try:
+            period = float(self.args.get('--period'))
+        except ValueError:
+            print("--period requires a number (e.g. --period=0.42)")
+            return 1
+
+        return self.change_loglevel(
+            address=self.args['<address>'],
+            logger=self.args['--name'],
+            level=self.args['--level'],
+            period=period,
+        )
+
+    def change_loglevel(self, address, logger, level, period):
+        client = Client.from_config(self.config)
+        body = {
+            'qualname': logger,
+            'loglevel': level,
+            'period': period,
+        }
+        service = client.container.lookup(address)
+        print("Changing logger '%s' of '%s' to '%s' for a period of %s seconds" %
+              (logger, address, level, period))
+        for instance in service:
+            client.request(instance.endpoint, 'lymph.change_loglevel', body)
+

--- a/lymph/cli/service.py
+++ b/lymph/cli/service.py
@@ -64,8 +64,9 @@ class InstanceCommand(Command):
 
     def run(self):
         debug = self.args.get('--debug')
+        loglevel = self.args.get('--loglevel', 'ERROR')
 
-        self._setup_container(debug)
+        self._setup_container(debug, loglevel)
 
         if debug:
             self._start_backdoor_terminal()
@@ -81,9 +82,10 @@ class InstanceCommand(Command):
 
         self.container.join()
 
-    def _setup_container(self, debug):
+    def _setup_container(self, debug, loglevel):
         self.container = create_container(self.config, worker=self.worker)
         self.container.debug = debug
+        self.container.loglevel = loglevel
         # Set global exception hook to send unhandled exception to the container's error_hook.
         sys.excepthook = self.container.excepthook
 

--- a/lymph/core/interfaces.py
+++ b/lymph/core/interfaces.py
@@ -1,5 +1,6 @@
 import textwrap
 import functools
+import logging
 
 import six
 
@@ -13,6 +14,7 @@ import gevent
 from gevent.event import AsyncResult
 
 
+logger = logging.getLogger(__name__)
 REQUEST_TIMEOUT = 3  # seconds.
 
 
@@ -195,6 +197,18 @@ class DefaultInterface(Interface):
         return {
             'methods': methods,
         }
+
+    @rpc()
+    def change_loglevel(self, qualname, loglevel, period=60):
+        curr_logger = logging.getLogger(qualname)
+
+        def reset():
+            logger.info("Resetting logger %s level to %s", qualname, self.container.loglevel)
+            curr_logger.setLevel(self.container.loglevel)
+
+        gevent.spawn_later(period, reset)
+        curr_logger.setLevel(loglevel)
+        logger.info("Changing logger %s level to %s", qualname, loglevel)
 
     @rpc()
     def get_metrics(self):

--- a/lymph/tests/integration/test_cli.py
+++ b/lymph/tests/integration/test_cli.py
@@ -45,19 +45,20 @@ class RequestCommandTests(CliIntegrationTestCase):
 class ListCommandTests(CliTestMixin, unittest.TestCase):
     def test_list(self):
         self.assert_lines_equal(['list'], u"""
-            {t.bold}config     {t.normal}Prints configuration for inspection
-            {t.bold}tail       {t.normal}Streams the log output of services to stderr
-            {t.bold}emit       {t.normal}Emits an event in the event system
-            {t.bold}request    {t.normal}Sends a single RPC request to a service and outputs the response
-            {t.bold}inspect    {t.normal}Describes the RPC interface of a service
-            {t.bold}discover   {t.normal}Shows available services
-            {t.bold}help       {t.normal}Displays help information about lymph
-            {t.bold}list       {t.normal}Lists all available commands
-            {t.bold}subscribe  {t.normal}Subscribes to event types and prints occurences on stdout
-            {t.bold}instance   {t.normal}Runs a single service instance
-            {t.bold}node       {t.normal}Runs a node service that manages a group of processes on the same machine
-            {t.bold}shell      {t.normal}Starts an interactive Python shell, locally or remotely
-            {t.bold}worker     {t.normal}Runs a worker instance
+            {t.bold}config           {t.normal}Prints configuration for inspection
+            {t.bold}tail             {t.normal}Streams the log output of services to stderr
+            {t.bold}emit             {t.normal}Emits an event in the event system
+            {t.bold}request          {t.normal}Sends a single RPC request to a service and outputs the response
+            {t.bold}inspect          {t.normal}Describes the RPC interface of a service
+            {t.bold}discover         {t.normal}Shows available services
+            {t.bold}help             {t.normal}Displays help information about lymph
+            {t.bold}list             {t.normal}Lists all available commands
+            {t.bold}subscribe        {t.normal}Subscribes to event types and prints occurences on stdout
+            {t.bold}instance         {t.normal}Runs a single service instance
+            {t.bold}node             {t.normal}Runs a node service that manages a group of processes on the same machine
+            {t.bold}shell            {t.normal}Starts an interactive Python shell, locally or remotely
+            {t.bold}worker           {t.normal}Runs a worker instance
+            {t.bold}change-loglevel  {t.normal}Set logging level of a service logger
         """.format(t=blessings.Terminal()), config=False)
 
 

--- a/lymph/tests/test_mockcontainer.py
+++ b/lymph/tests/test_mockcontainer.py
@@ -100,7 +100,7 @@ class BasicMockTest(RPCServiceTestCase):
         self.assertEqual(set(m['name'] for m in methods), set([
             'upper.fail', 'upper.upper', 'upper.auto_nack', 'upper.just_ack',
             'lymph.status', 'lymph.inspect', 'lymph.ping', 'upper.indirect_upper',
-            'lymph.get_metrics', 'upper.get_trace_id',
+            'lymph.get_metrics', 'upper.get_trace_id', 'lymph.change_loglevel',
         ]))
 
     def test_trace_id_propagates_via_rpc(self):

--- a/lymph/utils/logging.py
+++ b/lymph/utils/logging.py
@@ -85,7 +85,7 @@ def setup_logging(config, loglevel, logfile):
     console_logconf = {
         'class': 'logging.StreamHandler',
         'formatter': '_trace',
-        'level': loglevel.upper(),
+        'level': 'DEBUG',
     }
     if logfile:
         console_logconf.update({
@@ -96,6 +96,6 @@ def setup_logging(config, loglevel, logfile):
     loggers = logconf.setdefault('loggers', {})
     loggers.setdefault('lymph', {
         'handlers': ['_console', '_zmqpub'],
-        'level': 'DEBUG',
+        'level': loglevel.upper(),
     })
     dictConfig(logconf)

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
             'tail = lymph.cli.tail:TailCommand',
             'config = lymph.cli.config:ConfigCommand',
             'worker = lymph.cli.service:WorkerCommand',
+            'change-loglevel = lymph.cli.loglevel:LogLevelCommand',
         ],
         'nose.plugins.0.10': ['lymph = lymph.testing.nose:LymphPlugin'],
         'pytest11': ['lymph = lymph.testing.pytest'],


### PR DESCRIPTION
It's really helpful to be able to change log level without
downtime to inspect behaviour of running service when tracking
bugs specially. The log level change will take effect for only
a given period of time after that it will be reseted.

Example:
$ lymph change-loglevel demo -n lymph -l DEBUG
Change loglevel of all instances of demo service to DEBUG of lymph logger.