### PR TITLE
fix max port for bind

### DIFF
--- a/lymph/core/rpc.py
+++ b/lymph/core/rpc.py
@@ -58,7 +58,7 @@ class ZmqRPCServer(Component):
         retries = 0
         while True:
             if not self.port:
-                port = random.randint(35536, 65536)
+                port = random.randrange(35536, 65536)
             try:
                 self.endpoint = 'tcp://%s:%s' % (self.ip, port)
                 endpoint = self.endpoint.encode('utf-8')


### PR DESCRIPTION
otherwise, there is 1/30001 chance that it will fail :)

Initially did this but not sure if it's worth complicating also not sure if `zmq.IDENTITY` needs to be set prior to bind, though probably not:

    def _bind_static_port(self, ip, port, max_retries=2, retry_delay=0):
        retries = 0
        endpoint = ('tcp://%s:%s' % (ip, port)).encode('utf-8')
        while True:
            try:
                self.recv_sock.bind(endpoint)
                break
            except zmq.ZMQError as e:
                if e.errno != errno.EADDRINUSE or retries >= max_retries:
                    raise
                logger.info('failed to bind to port %s (errno=%s), trying again.', port, e.errno)
                retries += 1
                if retry_delay:
                    gevent.sleep(retry_delay)
                continue

    def _bind(self, max_retries=2, retry_delay=0):
        assert not self.bound, 'already bound (endpoint=%s)' % self.endpoint
        self.send_sock = self.zctx.socket(zmq.ROUTER)
        self.recv_sock = self.zctx.socket(zmq.ROUTER)
        if self.port:
            self._bind_static_port(self.ip, self.port, max_retries=max_retries, retry_delay=retry_delay)
        else:
            self.port = self.recv_sock.bind_to_random_port('tcp://%s' % self.ip)

        self.endpoint = 'tcp://%s:%s' % (self.ip, self.port)
        endpoint = self.endpoint.encode('utf-8')
        self.recv_sock.setsockopt(zmq.IDENTITY, endpoint)
        self.send_sock.setsockopt(zmq.IDENTITY, endpoint)
        self.bound = True