### PR TITLE
Fail cleanly when request handlers don't return response objects

### DIFF
--- a/lymph/tests/integration/test_web_interface.py
+++ b/lymph/tests/integration/test_web_interface.py
@@ -40,10 +40,14 @@ class Web(WebServiceInterface):
         HandledRule("/bar/", endpoint="bar", handler=HandledRuleHandler),
         Rule("/fail/", endpoint="fail"),
         Rule("/fail-wrong-endpoint/", endpoint=42),
+        Rule("/bad-handler-return-type/", endpoint='return_none')
     ])
 
     def test(self, request):
         return Response("method test")
+
+    def return_none(self, request):
+        pass
 
 
 class CustomErrorHandlingWeb(Web):
@@ -98,6 +102,10 @@ class WebIntegrationTest(WebServiceTestCase):
 
         response = self.client.post("/baz/")
         self.assertEqual(response.status_code, 405)
+
+    def test_bad_handler_return_type(self):
+        response = self.client.get("/bad-handler-return-type/")
+        self.assertIn('X-Trace-Id', response.headers)
 
 
 class CustomErrorHandlingWebIntegrationTest(WebIntegrationTest):

--- a/lymph/web/interfaces.py
+++ b/lymph/web/interfaces.py
@@ -122,6 +122,8 @@ class WebServiceInterface(Interface):
                 response = handler.dispatch(kwargs)
             else:
                 response = handler(request, **kwargs)
+            if not isinstance(response, Response):
+                raise TypeError('%r is not a valid response - expected werkzeug.wrappers.Response instance' % response)
         except MethodNotAllowed:
             response = self.MethodNotAllowed().get_response(request.environ)
         except HTTPException as e:


### PR DESCRIPTION
https://github.com/deliveryhero/lymph/issues/287