### PR TITLE
Don't kill the entire CLI when some import fails

### DIFF
--- a/lymph/cli/base.py
+++ b/lymph/cli/base.py
@@ -63,21 +63,6 @@ class Command(object):
         raise NotImplementedError
 
 
-class FailedToLoadCommand(Command):
-    def __init__(self, exc_type, exc_value, exc_traceback):
-        self.exc_type = exc_type
-        self.exc_value = exc_value
-        self.exc_traceback = exc_traceback
-        self.short_description = "Command unavailable: %s: %s" % (exc_type, exc_value)
-
-    @classmethod
-    def get_help(cls):
-        raise NotImplementedError("Command failed to load required module")
-
-    def run(self):
-        raise NotImplementedError("Command failed to load required module")
-
-
 _command_class_cache = None
 
 
@@ -97,7 +82,6 @@ def get_command_classes():
                 _command_class_cache[name] = cls
             except ImportError:
                 logger.exception('Import error for command entry point %s', entry_point)
-                _command_class_cache[name] = FailedToLoadCommand(sys.exc_type, sys.exc_value, sys.exc_traceback)
     return _command_class_cache
 
 

--- a/lymph/cli/base.py
+++ b/lymph/cli/base.py
@@ -96,8 +96,7 @@ def get_command_classes():
                 cls.name = name
                 _command_class_cache[name] = cls
             except ImportError:
-                logger.error('Import error in %s, %s', entry_point, name)
-                traceback.print_exc()
+                logger.exception('Import error for command entry point %s', entry_point)
                 _command_class_cache[name] = FailedToLoadCommand(sys.exc_type, sys.exc_value, sys.exc_traceback)
     return _command_class_cache
 

--- a/lymph/cli/main.py
+++ b/lymph/cli/main.py
@@ -70,6 +70,9 @@ def main(argv=None):
     from lymph.cli.base import get_command_class
     from lymph.utils import logging as lymph_logging
 
+    bootup_handler = logging.StreamHandler()
+    logging.getLogger().addHandler(bootup_handler)
+
     args = docopt.docopt(HELP, argv, version=VERSION, options_first=True)
     name = args.pop('<command>')
     argv = args.pop('<args>')
@@ -83,6 +86,7 @@ def main(argv=None):
 
     config = setup_config(args) if command_cls.needs_config else None
 
+    logging.getLogger().removeHandler(bootup_handler)
     if config:
         loglevel = args.get('--loglevel', 'ERROR')
         logfile = args.get('--logfile')


### PR DESCRIPTION
Whenever something was wrong with any of the many services which registered CLI entry points, the entire lymph command line interface stopped working. This got annoying (and will get worse over time as more services are added).

This PR is a proposal for a fix of this situation.